### PR TITLE
fix(hero): resolve text overlay issue with buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -320,7 +320,7 @@ p {
 /* Contenu dynamique du carrousel */
 .hero-dynamic-content {
     position: relative;
-    min-height: 120px;
+    min-height: 160px;
 }
 
 .hero-slide-content {
@@ -465,13 +465,14 @@ p {
 .hero-description {
     font-size: clamp(1.1rem, 2.2vw, 1.4rem);
     color: rgba(255, 255, 255, 0.9);
-    margin-bottom: 5rem;
-    line-height: 1.6;
+    margin-bottom: 6rem;
+    line-height: 1.7;
     max-width: 700px;
     margin-left: auto;
     margin-right: auto;
     text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
     animation: descriptionReveal 2s ease-out 0.9s both;
+    padding-bottom: 1rem;
 }
 
 @keyframes descriptionReveal {
@@ -618,7 +619,7 @@ p {
     }
     
     .hero-dynamic-content {
-        min-height: 100px;
+        min-height: 140px;
     }
     
     .hero-services {
@@ -656,7 +657,8 @@ p {
 @media (max-width: 480px) {
     .hero-description {
         font-size: 1rem;
-        margin-bottom: 2.5rem;
+        margin-bottom: 3.5rem;
+        padding-bottom: 1.5rem;
     }
     
     /* Positioning spécifique mobile pour Clarisse et Mathieu */


### PR DESCRIPTION
- Increased min-height of hero-dynamic-content from 120px to 160px (140px on mobile)
- Added more bottom margin to hero-description (5rem to 6rem, 2.5rem to 3.5rem on mobile)
- Added padding-bottom to prevent text/button overlap
- Improved line-height for better text spacing
- Ensured proper spacing for multi-line French text in hero section