### PR TITLE
revert(mobile): remove viewport fix - restore simple 100vh height

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,8 +2,7 @@
    VARIABLES CSS - PALETTE PSYCHÉDÉLIQUE 60-70
    ============================================== */
 :root {
-    /* Viewport height dynamique pour mobile */
-    --vh: 1vh;
+
     
     /* Couleurs principales */
     --yellow-primary: #FFD700;    /* Jaune vif */
@@ -250,7 +249,6 @@ p {
 .hero {
     position: relative;
     height: 100vh;
-    height: calc(var(--vh, 1vh) * 100); /* Utilise la vraie hauteur calculée en JS */
     display: flex;
     align-items: center;
     justify-content: center;

--- a/js/script.js
+++ b/js/script.js
@@ -20,8 +20,7 @@ document.addEventListener('DOMContentLoaded', function() {
 function initializeApp() {
     console.log('🌼 Sweet Daisies Orchestra - Site chargé !');
     
-    // Correction viewport mobile en premier
-    fixMobileViewport();
+
     
     // Initialisation des fonctionnalités
     initNavigation();
@@ -853,48 +852,7 @@ addCustomCSS();
 // CORRECTION VIEWPORT MOBILE
 // ==============================================
 
-/**
- * Corrige les problèmes de viewport sur mobile (iPhone Safari notamment)
- * Le problème : 100vh inclut la barre d'adresse sur Safari mobile
- * La solution : Calculer la vraie hauteur disponible
- */
-function fixMobileViewport() {
-    // Fonction pour calculer et appliquer la vraie hauteur de viewport
-    function setRealVH() {
-        const vh = window.innerHeight * 0.01;
-        document.documentElement.style.setProperty('--vh', `${vh}px`);
-        
-        // Log pour debug en mode développement
-        if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
-            console.log(`📱 Viewport mobile corrigé: ${vh}px (height: ${window.innerHeight}px)`);
-        }
-    }
-    
-    // Appliquer immédiatement
-    setRealVH();
-    
-    // Recalculer lors des redimensionnements (orientation, barre d'adresse)
-    window.addEventListener('resize', setRealVH);
-    window.addEventListener('orientationchange', () => {
-        // Délai pour laisser le temps au navigateur de s'adapter
-        setTimeout(setRealVH, 100);
-    });
-    
-    // Détection spécifique iOS/Safari pour des corrections supplémentaires
-    const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
-    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-    
-    if (isIOS || isSafari) {
-        document.body.classList.add('ios-device');
-        
-        // Correction supplémentaire pour iPhone en mode portrait
-        if (window.screen.height > window.screen.width) {
-            document.body.classList.add('portrait-mode');
-        }
-        
-        console.log(`🍎 Appareil iOS/Safari détecté - Corrections appliquées`);
-    }
-}
+
 
 // ==============================================
 // DEBUGGING ET DÉVELOPPEMENT


### PR DESCRIPTION
- Remove complex mobile viewport calculation that caused title cutoff on iPhone 15
- Restore simple height: 100vh for hero section
- Remove fixMobileViewport() JavaScript function
- User preference: Better to have slight text overlay than cut-off title
- Mobile users are primary audience for this website

The previous mobile-first approach where text entered button area was more user-friendly than having the main title completely hidden on mobile devices.