### PR TITLE
fix(mobile): iPhone display optimization while keeping perfect desktop

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -654,9 +654,15 @@ p {
 }
 
 @media (max-width: 480px) {
+    .hero {
+        height: 100vh;
+        min-height: 100vh;
+        padding: 20px 0; /* Ajouter du padding pour éviter les coupures */
+    }
+    
     .hero-description {
         font-size: 1rem;
-        margin-bottom: 0.5rem;
+        margin-bottom: 2rem;
     }
     
     .service-item {


### PR DESCRIPTION
- Keep desktop margin-bottom: 1rem (perfect as confirmed by user)
- Increase mobile margin-bottom to 2rem (from 0.5rem) for better spacing
- Add mobile hero padding: 20px 0 to prevent title/button cutoff on iPhone
- Address iPhone Safari viewport issues without affecting desktop experience
- User feedback: 'pour mon pc portable c'est parfait' + iPhone needs adjustment

Maintains perfect desktop experience while fixing iPhone display issues.