### PR TITLE
balance(hero): fine-tune desktop/mobile spacing equilibrium

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -465,7 +465,7 @@ p {
 .hero-description {
     font-size: clamp(1.1rem, 2.2vw, 1.4rem);
     color: rgba(255, 255, 255, 0.9);
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
     line-height: 1.6;
     max-width: 700px;
     margin-left: auto;
@@ -655,14 +655,17 @@ p {
 
 @media (max-width: 480px) {
     .hero {
-        height: 100vh;
-        min-height: 100vh;
-        padding: 20px 0; /* Ajouter du padding pour éviter les coupures */
+        min-height: 85vh; /* Utiliser min-height au lieu de height pour plus de flexibilité */
+        padding: 10px 0; /* Padding réduit mais présent */
+    }
+    
+    .hero-content {
+        padding: 20px 15px; /* Padding sur le contenu plutôt que sur le hero */
     }
     
     .hero-description {
         font-size: 1rem;
-        margin-bottom: 2rem;
+        margin-bottom: 1.5rem; /* Réduit de 2rem à 1.5rem */
     }
     
     .service-item {


### PR DESCRIPTION
Desktop adjustments:
- Increase margin-bottom from 1rem to 1.5rem to prevent text touching buttons
- Maintains natural text-button proximity without overlap

Mobile (iPhone) adjustments:
- Change hero height from 100vh to min-height: 85vh for better flexibility
- Add padding to hero-content instead of hero container
- Reduce hero-description margin-bottom from 2rem to 1.5rem
- Should prevent title cutoff while keeping proper button visibility

Goal: Perfect spacing on both desktop and iPhone simultaneously