### PR TITLE
fix: Resolve hero text overlap with service buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -320,7 +320,7 @@ p {
 /* Contenu dynamique du carrousel */
 .hero-dynamic-content {
     position: relative;
-    min-height: 120px;
+    min-height: 150px;
 }
 
 .hero-slide-content {


### PR DESCRIPTION
- Increase .hero-dynamic-content min-height from 120px to 150px
- Prevents text2 (hero-description) from overlapping with service buttons
- Tested and confirmed working on iPhone and MacBook Pro
- Maintains design integrity while fixing spacing issue